### PR TITLE
Guest Count

### DIFF
--- a/ohsyspres/cli.py
+++ b/ohsyspres/cli.py
@@ -10,10 +10,21 @@ class DeviceTuple(click.Tuple):
     name = "device"
 
     def convert(self, value, param, ctx):
+        mac = value[0].upper().replace(':', '')
         return (
-            value[0].replace(':', '').lower(),
+            ':'.join(mac[i:i+2] for i in range(0, 12, 2)),
             value[1]
         )
+
+
+class MacAddress(click.ParamType):
+    name = 'macaddress'
+
+    def convert(self, value: str, param, ctx):
+        if value:
+            value = value.upper().replace(':', '')
+            return ':'.join(value[i:i+2] for i in range(0, 12, 2))
+        return None
 
 
 @click.command()
@@ -27,12 +38,28 @@ class DeviceTuple(click.Tuple):
     '--openhab-url', help='URL for OpenHAB', envvar='OHSYSLOG_URL', required=True,
 )
 @click.option(
+    '--router-host', help='Router ip for guest count lookup', envvar='ROUTER_HOST'
+)
+@click.option(
+    '--router-creds', nargs=2, type=click.Tuple([str, str]), envvar='ROUTER_CREDS',
+    help=('Username Password for router, Scoped Read Only account recommended,'
+          'export ROUTER_CREDS="username reallygoodropassword')
+)
+@click.option(
     '--watch-device', '-w', nargs=2, type=DeviceTuple([str, str]), multiple=True,
     help="devices to watch/item names. ie -w 846969F9D00F Phone -w 07559D07C215 Laptop",
 )
 @click.option(
     '--append-network', is_flag=True, default=False,
     help='Append Wifi Network to item, ie Phone_MyWiFi',
+)
+@click.option(
+    '--ignore-device', '-i', type=MacAddress(), multiple=True,
+    help="Devices to ignore. ie -i 846969F9D01F"
+)
+@click.option(
+    '--guest-network', '-g', multiple=True,
+    help='Guest networks for simple device counts'
 )
 @click.option(
     '--debug', is_flag=True, default=False, help='Enable debug logging'

--- a/ohsyspres/parsers.py
+++ b/ohsyspres/parsers.py
@@ -30,7 +30,7 @@ class MikrotikParser:
         payload = {}
         payload["topic"] = parsed[0]
         payload["level"] = parsed[1]
-        payload["device"] = parsed[2].replace(':', '').lower()
+        payload["device"] = parsed[2].upper()
         payload["network"] = parsed[3].replace('-', '_')
         payload["state"] = parsed[4]
         payload["switch"] = 'ON' if parsed[4] == 'connected' else 'OFF'

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
         'click',
         'requests',
         'pyparsing',
+        'librouteros',
     ],
     entry_points={
         'console_scripts': [
@@ -29,6 +30,8 @@ setup(
             'pytest-pylint',
             'pylint',
             'pytest-flake8',
+            'types-click',
+            'types-requests',
         ],
         'test': [
             'pytest',
@@ -37,6 +40,8 @@ setup(
             'pytest-pylint',
             'pylint',
             'pytest-flake8',
+            'types-click',
+            'types-requests',
         ]
     }
 )

--- a/tests/parsers.py
+++ b/tests/parsers.py
@@ -14,7 +14,7 @@ class BaseTests:
             self.assertEqual(self.disconnected['switch'], 'OFF')
 
         def test_device(self):
-            self.assertEqual(self.disconnected['device'], '846c6af9d00f')
+            self.assertEqual(self.disconnected['device'], '84:6C:6A:F9:D0:0F')
 
         def test_disconnected_network(self):
             self.assertEqual(self.disconnected['network'], 'wifi_network')


### PR DESCRIPTION
Adds the ability to log into a RouteOS based WAP and count connected guests. It also adds an ignore flag to avoid including devices in the count.

Enhanced MAC normalisation process for easier filtering out ignored/existing devices from guest count.