### PR TITLE
MikroTik CAPsMAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,23 @@ ohsyspres --help
 Usage: ohsyspres [OPTIONS]
 
 Options:
-  --host TEXT                   IP to advertise on, default 0.0.0.0
-  --port INTEGER                Port to listen on, default 1514
-  --openhab-url TEXT            URL for OpenHAB  [required]
-  -w, --watch-device DEVICE...  devices to watch/item names. ie -w
-                                846969F9D00F Phone -w 07559D07C215 Laptop
+  --host TEXT                     IP to advertise on, default 0.0.0.0
+  --port INTEGER                  Port to listen on, default 1514
+  --openhab-url TEXT              URL for OpenHAB  [required]
+  --router-host TEXT              Router ip for guest count lookup
+  --router-creds <TEXT TEXT>...   Username Password for router, Scoped Read
+                                  Only account recommended,export
+                                  ROUTER_CREDS="username reallygoodropassword
 
-  --append-network              Append Wifi Network to item, ie Phone_MyWiFi
-  --debug                       Enable debug logging
-  --log-file FILE               Path to log file
-  --help                        Show this message and exit.
+  -w, --watch-device DEVICE...    devices to watch/item names. ie -w
+                                  846969F9D00F Phone -w 07559D07C215 Laptop
+
+  --append-network                Append Wifi Network to item, ie Phone_MyWiFi
+  -i, --ignore-device MACADDRESS  Devices to ignore. ie -i 846969F9D01F
+  -g, --guest-network TEXT        Guest networks for simple device counts
+  --debug                         Enable debug logging
+  --log-file FILE                 Path to log file
+  --help                          Show this message and exit.
 ```
 
 ## Running

--- a/ohsyspres/cli.py
+++ b/ohsyspres/cli.py
@@ -42,6 +42,7 @@ class MacAddress(click.ParamType):
 )
 @click.option(
     '--router-creds', nargs=2, type=click.Tuple([str, str]), envvar='ROUTER_CREDS',
+    default=[None] * 2,
     help=('Username Password for router, Scoped Read Only account recommended,'
           'export ROUTER_CREDS="username reallygoodropassword')
 )

--- a/ohsyspres/parsers.py
+++ b/ohsyspres/parsers.py
@@ -9,6 +9,7 @@ from pyparsing import (
     string,
     Regex,
 )
+from pyparsing import Optional as Opt
 
 
 class MikrotikParser:
@@ -17,7 +18,7 @@ class MikrotikParser:
         topic = Word(string.ascii_lowercase) + Suppress(",")
         level = Word(string.ascii_lowercase)
         device = Word(alphas + nums + "_" + "-" + "." + ":") + Suppress("@")
-        network = Word(alphas + '-') + Suppress(":")
+        network = Word(alphas + nums + '-') + Suppress(Opt(":") + Opt(" "))
         state = Word(alphas) + Suppress(",")
         message = Regex(".*")
 

--- a/ohsyspres/parsers.py
+++ b/ohsyspres/parsers.py
@@ -32,7 +32,7 @@ class MikrotikParser:
         payload["topic"] = parsed[0]
         payload["level"] = parsed[1]
         payload["device"] = parsed[2].upper()
-        payload["network"] = parsed[3].replace('-', '_')
+        payload["network"] = parsed[3]
         payload["state"] = parsed[4]
         payload["switch"] = 'ON' if parsed[4] == 'connected' else 'OFF'
         payload["message"] = parsed[5]

--- a/ohsyspres/presence.py
+++ b/ohsyspres/presence.py
@@ -100,8 +100,7 @@ class SyslogUDPHandler(socketserver.BaseRequestHandler):
         elif not item:
             return
 
-        item_url = '{}/rest/items/{}'.format(
-            self.openhab_url, item)
+        item_url = f'{self.openhab_url}/rest/items/{item}'
         try:
             result = requests.post(item_url, data=data,
                                    headers={'Content-Type': 'text/plain'})

--- a/ohsyspres/presence.py
+++ b/ohsyspres/presence.py
@@ -51,7 +51,7 @@ class SyslogUDPHandler(socketserver.BaseRequestHandler):
             return None, None
 
         if self.append_network:
-            item = '{}_{}'.format(item, network)
+            item = f'{item}_{network}'.replace('-', '_')
 
         return item, switch
 

--- a/tests/parsers.py
+++ b/tests/parsers.py
@@ -16,9 +16,6 @@ class BaseTests:
         def test_device(self):
             self.assertEqual(self.disconnected['device'], '84:6C:6A:F9:D0:0F')
 
-        def test_disconnected_network(self):
-            self.assertEqual(self.disconnected['network'], 'wifi_network')
-
 
 class TestMirkotikParser(BaseTests.Parser):
 
@@ -34,3 +31,32 @@ class TestMirkotikParser(BaseTests.Parser):
 
     def test_disconnected_state(self):
         self.assertEqual(self.disconnected['state'], 'disconnected')
+
+    def test_disconnected_network(self):
+        self.assertEqual(self.disconnected['network'], 'wifi-network')
+
+    def test_topic(self):
+        self.assertEqual(self.disconnected['topic'], 'wireless')
+
+
+class TestMirkotikCapsParser(BaseTests.Parser):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.connected = MikrotikParser().parse(
+            'caps,info 84:6c:6a:F9:D0:0F@prefix-ap-1 connected, signal strength -36')
+        cls.disconnected = MikrotikParser().parse((
+            'caps,info 84:6c:6a:F9:D0:0F@prefix-ap-1 disconnected, received deauth: '
+            'ending station leaving (3), signal strength -42'))
+
+    def test_connected_state(self):
+        self.assertEqual(self.connected['state'], 'connected')
+
+    def test_disconnected_state(self):
+        self.assertEqual(self.disconnected['state'], 'disconnected')
+
+    def test_disconnected_network(self):
+        self.assertEqual(self.disconnected['network'], 'prefix-ap-1')
+
+    def test_topic(self):
+        self.assertEqual(self.disconnected['topic'], 'caps')


### PR DESCRIPTION
Adds                                      
- Parsing CAPsMAN logs
- Detects CAPsMAN/Wireless logs and looks up the relevant guest registration table

Changes
- Dashes replaced in network only if 'append-network' flag specified

Fixes
- Click Type error with no router creds provided